### PR TITLE
ctrl + oem_minus not working for one word right when cursor is active…

### DIFF
--- a/keybindings.json
+++ b/keybindings.json
@@ -37,8 +37,8 @@
         "command": "-workbench.action.navigateBack"
     },
     {
-        "key": "ctrl+right",
-        "command": "workbench.action.navigateForward"
+      "key": "ctrl+shift+oem_minus",
+      "command": "workbench.action.navigateForward"
     },
     {
         "key": "alt+right",


### PR DESCRIPTION
… on line cause of workbench.action.navigateForward navigation forward. workbench.action.navigateForward shortcut changed to ctrl + shift + oem_minus which generally reference to it.